### PR TITLE
With WX 3.1.3 Error Fix

### DIFF
--- a/Source/Core/DolphinWX/WxUtils.cpp
+++ b/Source/Core/DolphinWX/WxUtils.cpp
@@ -155,13 +155,13 @@ void SetWindowSizeAndFitToScreen(wxTopLevelWindow* tlw, wxPoint pos, wxSize size
   if (wxDisplay::GetCount() > 1)
     screen_geometry = GetVirtualScreenGeometry();
   else
-    screen_geometry = wxDisplay(0).GetClientArea();
+    screen_geometry = wxDisplay((unsigned int)0).GetClientArea();
 
   // Initialize the default size if it is wxDefaultSize or otherwise negative.
   default_size.DecTo(screen_geometry.GetSize());
   default_size.IncTo(tlw->GetMinSize());
   if (!default_size.IsFullySpecified())
-    default_size.SetDefaults(wxDisplay(0).GetClientArea().GetSize() / 2);
+    default_size.SetDefaults((unsigned int)wxDisplay(0).GetClientArea().GetSize() / 2);
 
   // If the position we're given doesn't make sense then go with the current position.
   // (Assuming the window was created with wxDefaultPosition then this should be reasonable)


### PR DESCRIPTION
I built with wx 3.1.3 at ubuntu 18.04

But, I see a next errorr message :
/Source/Core/DolphinWX/WxUtils.cpp:158:34: error: call of overloaded ‘wxDisplay(int)’ is ambiguous
     screen_geometry = wxDisplay(0).GetClientArea();

Because wxDisplay function structure:
wxDisplay(unsigned int)

So, I fix to next:
wxDisplay((unsigned int)0);

I can built complete.